### PR TITLE
docs(schemas): add v1 schema pages and site navigation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,52 +1,58 @@
 name: Deploy Documentation
+
 on:
   push:
-    branches:
-      - main
-  # Allow manual triggering
+    branches: [ main ]
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+          pip install mkdocs-git-revision-date-localized-plugin
+      - name: MkDocs build (no deploy)
+        run: mkdocs build --strict
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          
-      - uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.x
-          
-      - name: Set cache ID
-        run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-        
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: ~/.cache
-          restore-keys: |
-            mkdocs-material-
-            
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           pip install mkdocs-material
           pip install mkdocs-git-revision-date-localized-plugin
           pip install mike
-          
-      - name: Deploy documentation with versioning
+      - name: Deploy with versioning
         run: |
-          # Deploy the current version as 'latest' and '1.0'
           mike deploy --push --update-aliases 1.0 latest
-          # Set latest as the default version
           mike set-default --push latest

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -1,0 +1,42 @@
+name: Validate JSON Schemas
+on:
+  push:
+    paths:
+      - 'schema/**/*.json'
+      - '.github/workflows/validate-schemas.yml'
+      - 'scripts/validate-schemas.js'
+  pull_request:
+    paths:
+      - 'schema/**/*.json'
+      - '.github/workflows/validate-schemas.yml'
+      - 'scripts/validate-schemas.js'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          npm init -y
+          npm install ajv ajv-formats
+
+      - name: Validate schemas
+        run: |
+          echo "Validating JSON Schemas (draft-07)"
+          node scripts/validate-schemas.js
+
+      - name: Schema summary
+        run: |
+          echo "Schema Summary"
+          echo "=============="
+          find schema -name "*.json" | wc -l | xargs echo "Total schemas:"
+          echo "- Common definitions: $(find schema/v1/common -name "*.json" | wc -l)"
+          echo "- Endpoint schemas: $(find schema/v1/endpoints -name "*.json" | wc -l)"
+          echo "- Response schemas: $(find schema/v1/responses -name "*.json" | wc -l)"
+          echo "Validation completed"

--- a/docs/schemas/common.md
+++ b/docs/schemas/common.md
@@ -1,0 +1,20 @@
+# Common Definitions
+
+Shared type definitions used across endpoint schemas.
+
+- Canonical: https://mojoatomic.github.io/rdcp-protocol/schema/v1/common/rdcp-common.json
+- Repository: schema/v1/common/rdcp-common.json
+
+This schema defines reusable elements such as:
+- protocolVersion (const: "rdcp/1.0")
+- timestamp (ISO 8601)
+- categoryName (uppercase + underscores)
+- tenantContext (id, isolationLevel, scope)
+- securityLevel, authMethod
+- metrics (callsTotal, callsPerSecond)
+
+Example usage (Node + Ajv):
+
+```javascript
+// Load and add the common schema by its canonical $id first
+```

--- a/docs/schemas/endpoints/control-request.md
+++ b/docs/schemas/endpoints/control-request.md
@@ -1,0 +1,24 @@
+# Control Request Schema
+
+Defines the request body for `POST /rdcp/v1/control`.
+
+- Canonical: https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/control-request.json
+- Repository: schema/v1/endpoints/control-request.json
+
+Key fields
+- action: "enable" | "disable" | "toggle" | "reset" | "status"
+- categories: string or array of categoryName
+- options: { temporary, duration, reason }
+
+Sample request
+
+```json
+{
+  "action": "enable",
+  "categories": ["DATABASE", "API_ROUTES"],
+  "options": { "temporary": true, "duration": "15m", "reason": "Investigating issue" }
+}
+```
+
+Validation tip
+- Use the common schema first to satisfy `$ref` resolutions, then compile this schema.

--- a/docs/schemas/endpoints/control-response.md
+++ b/docs/schemas/endpoints/control-response.md
@@ -1,0 +1,33 @@
+# Control Response Schema
+
+Defines the response body for `POST /rdcp/v1/control`.
+
+- Canonical: https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/control-response.json
+- Repository: schema/v1/endpoints/control-response.json
+
+Key fields
+- protocol, timestamp, action, categories, status, message
+- changes[]: category, previousState, newState, temporary, effectiveAt, expiresAt
+
+Sample response
+
+```json
+{
+  "protocol": "rdcp/1.0",
+  "timestamp": "2025-09-17T10:30:00Z",
+  "action": "enable",
+  "categories": ["DATABASE"],
+  "status": "success",
+  "message": "Enabled categories",
+  "changes": [
+    {
+      "category": "DATABASE",
+      "previousState": false,
+      "newState": true,
+      "temporary": true,
+      "effectiveAt": "2025-09-17T10:30:00Z",
+      "expiresAt": "2025-09-17T10:45:00Z"
+    }
+  ]
+}
+```

--- a/docs/schemas/endpoints/discovery-response.md
+++ b/docs/schemas/endpoints/discovery-response.md
@@ -1,0 +1,34 @@
+# Discovery Response Schema
+
+Defines the response body for `GET /rdcp/v1/discovery`.
+
+- Canonical: https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/discovery-response.json
+- Repository: schema/v1/endpoints/discovery-response.json
+
+Key fields
+- protocol, timestamp
+- categories[]: name, description, enabled, temporary, metrics
+- performance: totalCalls, callsPerSecond, categoryBreakdown
+
+Sample response
+
+```json
+{
+  "protocol": "rdcp/1.0",
+  "timestamp": "2025-09-17T10:30:00Z",
+  "categories": [
+    {
+      "name": "DATABASE",
+      "description": "Database operations",
+      "enabled": true,
+      "temporary": false,
+      "metrics": { "callsTotal": 1234, "callsPerSecond": 2.3 }
+    }
+  ],
+  "performance": {
+    "totalCalls": 45678,
+    "callsPerSecond": 2.3,
+    "categoryBreakdown": { "DATABASE": 1234 }
+  }
+}
+```

--- a/docs/schemas/endpoints/health-response.md
+++ b/docs/schemas/endpoints/health-response.md
@@ -1,0 +1,24 @@
+# Health Response Schema
+
+Defines the response body for `GET /rdcp/v1/health`.
+
+- Canonical: https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/health-response.json
+- Repository: schema/v1/endpoints/health-response.json
+
+Key fields
+- protocol, timestamp, status: "healthy" | "degraded" | "unhealthy"
+- checks[]: name, status, duration
+
+Sample response
+
+```json
+{
+  "protocol": "rdcp/1.0",
+  "timestamp": "2025-09-17T10:30:00Z",
+  "status": "healthy",
+  "checks": [
+    { "name": "redis", "status": "pass", "duration": "5ms" },
+    { "name": "db", "status": "pass", "duration": "8ms" }
+  ]
+}
+```

--- a/docs/schemas/endpoints/status-response.md
+++ b/docs/schemas/endpoints/status-response.md
@@ -1,0 +1,23 @@
+# Status Response Schema
+
+Defines the response body for `GET /rdcp/v1/status`.
+
+- Canonical: https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/status-response.json
+- Repository: schema/v1/endpoints/status-response.json
+
+Key fields
+- protocol, timestamp, enabled
+- categories: map of categoryName -> boolean
+- performance: callsTotal, callsPerSecond
+
+Sample response
+
+```json
+{
+  "protocol": "rdcp/1.0",
+  "timestamp": "2025-09-17T10:30:00Z",
+  "enabled": true,
+  "categories": { "DATABASE": true, "API_ROUTES": false },
+  "performance": { "callsTotal": 45678, "callsPerSecond": 2.3 }
+}
+```

--- a/docs/schemas/index.md
+++ b/docs/schemas/index.md
@@ -1,0 +1,25 @@
+# JSON Schemas
+
+The RDCP protocol publishes versioned JSON Schemas for all request and response message types. These schemas provide a precise, machine‑readable definition of message structure for implementers.
+
+- Canonical base URL: https://mojoatomic.github.io/rdcp-protocol/schema/v1/
+- Meta‑schema: http://json-schema.org/draft-07/schema
+
+Schema categories
+
+- Common Types
+  - Shared type definitions used across endpoints
+- Endpoints
+  - Request/response schemas for all RDCP endpoints
+- Response Types
+  - Standard error response format
+
+Usage
+
+- Programmatic validation (e.g., Ajv, python-jsonschema)
+- CI validation of example payloads
+- Code generation for strongly typed clients/servers
+
+See also:
+- How to validate locally: scripts/validate-schemas.js
+- Full usage examples (Node, Python, Go, Java): schema/README.md

--- a/docs/schemas/responses/error.md
+++ b/docs/schemas/responses/error.md
@@ -1,0 +1,22 @@
+# Error Response Schema
+
+Defines the standard error response envelope used across endpoints.
+
+- Canonical: https://mojoatomic.github.io/rdcp-protocol/schema/v1/responses/error.json
+- Repository: schema/v1/responses/error.json
+
+Key fields
+- error: { code, message, details?, protocol }
+
+Sample response
+
+```json
+{
+  "error": {
+    "code": "RDCP_VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": { "field": "categories" },
+    "protocol": "rdcp/1.0"
+  }
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,16 @@ nav:
   - Home: index.md
   - Protocol Specification: rdcp-protocol-specification.md
   - Implementation Guide: rdcp-implementation-guide.md
-  - Protocol Schemas: protocol-schemas.md
+  - Schemas:
+    - Overview: schemas/index.md
+    - Common Types: schemas/common.md
+    - Endpoints:
+      - Control Request: schemas/endpoints/control-request.md
+      - Control Response: schemas/endpoints/control-response.md
+      - Discovery Response: schemas/endpoints/discovery-response.md
+      - Status Response: schemas/endpoints/status-response.md
+      - Health Response: schemas/endpoints/health-response.md
+    - Response Types:
+      - Error Response: schemas/responses/error.md
   - Error Codes: error-codes.md
   - Compliance Report: PROTOCOL-COMPLIANCE-REPORT.md

--- a/schema/v1/common/rdcp-common.json
+++ b/schema/v1/common/rdcp-common.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/common/rdcp-common.json",
+  "title": "RDCP Protocol Common Definitions v1.0",
+  "description": "Common schema definitions for the Runtime Debug Control Protocol (RDCP) v1.0",
+  "$defs": {
+    "protocolVersion": {
+      "type": "string",
+      "const": "rdcp/1.0",
+      "description": "RDCP protocol version identifier"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp in UTC"
+    },
+    "categoryName": {
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]*$",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Debug category name (uppercase, alphanumeric with underscores)"
+    },
+    "tenantContext": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique tenant identifier"
+        },
+        "isolationLevel": {
+          "type": "string",
+          "enum": ["global", "process", "namespace", "organization"],
+          "description": "Tenant isolation level"
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["global", "tenant-isolated"],
+          "description": "Tenant scope indicator"
+        }
+      },
+      "required": ["id", "isolationLevel", "scope"],
+      "additionalProperties": false
+    },
+    "securityLevel": {
+      "type": "string",
+      "enum": ["basic", "standard", "enterprise"],
+      "description": "RDCP security implementation level"
+    },
+    "authMethod": {
+      "type": "string",
+      "enum": ["api-key", "bearer", "mtls", "hybrid"],
+      "description": "Authentication method identifier"
+    },
+    "httpStatusCode": {
+      "type": "integer",
+      "minimum": 100,
+      "maximum": 599,
+      "description": "HTTP status code"
+    },
+    "rdcpErrorCode": {
+      "type": "string",
+      "enum": [
+        "RDCP_AUDIT_WRITE_FAILED",
+        "RDCP_AUTH_REQUIRED", 
+        "RDCP_CATEGORY_NOT_FOUND",
+        "RDCP_CONFIGURATION_ERROR",
+        "RDCP_FORBIDDEN",
+        "RDCP_INTERNAL_ERROR",
+        "RDCP_INVALID_ACTION",
+        "RDCP_INVALID_CATEGORY",
+        "RDCP_INVALID_CLIENT",
+        "RDCP_INVALID_PROTOCOL",
+        "RDCP_INVALID_TOKEN",
+        "RDCP_MALFORMED_REQUEST",
+        "RDCP_MISSING_PARAMETER",
+        "RDCP_NOT_FOUND",
+        "RDCP_RATE_LIMITED",
+        "RDCP_RATE_LIMIT_MISCONFIGURED",
+        "RDCP_REQUEST_ID_INVALID",
+        "RDCP_SERVER_ERROR",
+        "RDCP_STORAGE_ERROR",
+        "RDCP_TIMEOUT",
+        "RDCP_TOKEN_EXPIRED",
+        "RDCP_UNAVAILABLE",
+        "RDCP_UNSUPPORTED_VERSION",
+        "RDCP_VALIDATION_ERROR"
+      ],
+      "description": "Standard RDCP error code"
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "callsTotal": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of debug calls"
+        },
+        "callsPerSecond": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Average debug calls per second"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/v1/endpoints/control-request.json
+++ b/schema/v1/endpoints/control-request.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/control-request.json",
+  "title": "RDCP Control Request v1.0",
+  "description": "Request schema for POST /rdcp/v1/control endpoint",
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["enable", "disable", "toggle", "reset", "status"],
+      "description": "Control action to perform on debug categories"
+    },
+    "categories": {
+      "oneOf": [
+        {
+          "$ref": "../common/rdcp-common.json#/$defs/categoryName"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "../common/rdcp-common.json#/$defs/categoryName"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ],
+      "description": "Debug category name(s) to control"
+    },
+    "options": {
+      "type": "object",
+      "properties": {
+        "temporary": {
+          "type": "boolean",
+          "description": "Whether the control change is temporary"
+        },
+        "duration": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Duration in seconds"
+            },
+            {
+              "type": "string",
+              "pattern": "^\\d+[smhdw]$",
+              "description": "Duration string (e.g., '15m', '2h', '1d')"
+            }
+          ],
+          "description": "Duration for temporary controls"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500,
+          "description": "Reason for the control change (for audit trail)"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Additional options for the control operation"
+    }
+  },
+  "required": ["action", "categories"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "action": "enable",
+      "categories": ["DATABASE", "API_ROUTES"],
+      "options": {
+        "temporary": true,
+        "duration": "15m",
+        "reason": "Investigating issue #1234"
+      }
+    },
+    {
+      "action": "disable", 
+      "categories": "DATABASE"
+    },
+    {
+      "action": "status",
+      "categories": ["DATABASE", "CACHE", "AUTH"]
+    }
+  ]
+}

--- a/schema/v1/endpoints/control-response.json
+++ b/schema/v1/endpoints/control-response.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/control-response.json",
+  "title": "RDCP Control Response v1.0",
+  "description": "Response schema for POST /rdcp/v1/control endpoint",
+  "type": "object",
+  "properties": {
+    "protocol": {
+      "$ref": "../common/rdcp-common.json#/$defs/protocolVersion"
+    },
+    "timestamp": {
+      "$ref": "../common/rdcp-common.json#/$defs/timestamp"
+    },
+    "action": {
+      "type": "string",
+      "enum": ["enable", "disable", "toggle", "reset", "status"],
+      "description": "Control action that was performed"
+    },
+    "categories": {
+      "type": "array",
+      "items": {
+        "$ref": "../common/rdcp-common.json#/$defs/categoryName"
+      },
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Debug categories that were affected"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["success", "partial", "failed"],
+      "description": "Overall operation status"
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable status message"
+    },
+    "changes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "$ref": "../common/rdcp-common.json#/$defs/categoryName"
+          },
+          "previousState": {
+            "type": "boolean",
+            "description": "Previous enabled/disabled state"
+          },
+          "newState": {
+            "type": "boolean",
+            "description": "New enabled/disabled state"
+          },
+          "temporary": {
+            "type": "boolean",
+            "description": "Whether this is a temporary change"
+          },
+          "effectiveAt": {
+            "$ref": "../common/rdcp-common.json#/$defs/timestamp"
+          },
+          "expiresAt": {
+            "$ref": "../common/rdcp-common.json#/$defs/timestamp"
+          }
+        },
+        "required": ["category", "previousState", "newState", "effectiveAt"],
+        "additionalProperties": false
+      },
+      "description": "Detailed changes made to each category"
+    },
+    "tenant": {
+      "$ref": "../common/rdcp-common.json#/$defs/tenantContext"
+    }
+  },
+  "required": ["protocol", "timestamp", "action", "categories", "status", "message"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "protocol": "rdcp/1.0",
+      "timestamp": "2025-09-17T10:30:00Z",
+      "action": "enable",
+      "categories": ["DATABASE"],
+      "status": "success",
+      "message": "Enabled categories",
+      "changes": [
+        {
+          "category": "DATABASE",
+          "previousState": false,
+          "newState": true,
+          "temporary": true,
+          "effectiveAt": "2025-09-17T10:30:00Z",
+          "expiresAt": "2025-09-17T10:45:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/schema/v1/endpoints/discovery-response.json
+++ b/schema/v1/endpoints/discovery-response.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/discovery-response.json",
+  "title": "RDCP Discovery Response v1.0",
+  "description": "Response schema for GET /rdcp/v1/discovery endpoint",
+  "type": "object",
+  "properties": {
+    "protocol": {
+      "$ref": "../common/rdcp-common.json#/$defs/protocolVersion"
+    },
+    "timestamp": {
+      "$ref": "../common/rdcp-common.json#/$defs/timestamp"
+    },
+    "categories": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "../common/rdcp-common.json#/$defs/categoryName"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable category description"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the category is currently enabled"
+          },
+          "temporary": {
+            "type": "boolean",
+            "description": "Whether the current state is temporary"
+          },
+          "metrics": {
+            "$ref": "../common/rdcp-common.json#/$defs/metrics"
+          }
+        },
+        "required": ["name", "description", "enabled", "temporary"],
+        "additionalProperties": false
+      },
+      "description": "Available debug categories"
+    },
+    "performance": {
+      "type": "object",
+      "properties": {
+        "totalCalls": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total debug calls across all categories"
+        },
+        "callsPerSecond": {
+          "type": "number", 
+          "minimum": 0,
+          "description": "Average calls per second across all categories"
+        },
+        "categoryBreakdown": {
+          "type": "object",
+          "patternProperties": {
+            "^[A-Z][A-Z0-9_]*$": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "description": "Call counts by category"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Overall performance metrics"
+    },
+    "tenant": {
+      "$ref": "../common/rdcp-common.json#/$defs/tenantContext"
+    }
+  },
+  "required": ["protocol", "timestamp", "categories"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "protocol": "rdcp/1.0",
+      "timestamp": "2025-09-17T10:30:00Z",
+      "categories": [
+        {
+          "name": "DATABASE",
+          "description": "Database operations",
+          "enabled": true,
+          "temporary": false,
+          "metrics": {
+            "callsTotal": 1234,
+            "callsPerSecond": 2.3
+          }
+        }
+      ],
+      "performance": {
+        "totalCalls": 45678,
+        "callsPerSecond": 2.3,
+        "categoryBreakdown": {
+          "DATABASE": 1234
+        }
+      }
+    }
+  ]
+}

--- a/schema/v1/endpoints/health-response.json
+++ b/schema/v1/endpoints/health-response.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/health-response.json",
+  "title": "RDCP Health Response v1.0",
+  "description": "Response schema for GET /rdcp/v1/health endpoint",
+  "type": "object",
+  "properties": {
+    "protocol": {
+      "$ref": "../common/rdcp-common.json#/$defs/protocolVersion"
+    },
+    "timestamp": {
+      "$ref": "../common/rdcp-common.json#/$defs/timestamp"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["healthy", "degraded", "unhealthy"],
+      "description": "Overall system health status"
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the health check component"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "fail", "warn"],
+            "description": "Component health status"
+          },
+          "duration": {
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?(ns|μs|ms|s)$",
+            "description": "Time taken for the health check"
+          }
+        },
+        "required": ["name", "status"],
+        "additionalProperties": false
+      },
+      "description": "Individual component health checks"
+    },
+    "tenant": {
+      "$ref": "../common/rdcp-common.json#/$defs/tenantContext"
+    }
+  },
+  "required": ["protocol", "timestamp", "status"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "protocol": "rdcp/1.0",
+      "timestamp": "2025-09-17T10:30:00Z",
+      "status": "healthy",
+      "checks": [
+        {
+          "name": "redis",
+          "status": "pass", 
+          "duration": "5ms"
+        },
+        {
+          "name": "db",
+          "status": "pass",
+          "duration": "8ms"
+        }
+      ]
+    }
+  ]
+}

--- a/schema/v1/endpoints/protocol-discovery.json
+++ b/schema/v1/endpoints/protocol-discovery.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/protocol-discovery.json",
+  "title": "RDCP Protocol Discovery Response v1.0",
+  "description": "Response schema for GET /.well-known/rdcp endpoint",
+  "type": "object",
+  "properties": {
+    "protocol": {
+      "$ref": "../common/rdcp-common.json#/$defs/protocolVersion"
+    },
+    "endpoints": {
+      "type": "object",
+      "properties": {
+        "discovery": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Debug system discovery endpoint path"
+        },
+        "control": {
+          "type": "string", 
+          "format": "uri-reference",
+          "description": "Runtime control endpoint path"
+        },
+        "status": {
+          "type": "string",
+          "format": "uri-reference", 
+          "description": "Status monitoring endpoint path"
+        },
+        "health": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Health check endpoint path"
+        }
+      },
+      "required": ["discovery", "control", "status", "health"],
+      "additionalProperties": false
+    },
+    "capabilities": {
+      "type": "object",
+      "properties": {
+        "multiTenancy": {
+          "type": "boolean",
+          "description": "Whether multi-tenancy is supported"
+        },
+        "performanceMetrics": {
+          "type": "boolean",
+          "description": "Whether performance metrics are available"
+        },
+        "temporaryControls": {
+          "type": "boolean",
+          "description": "Whether temporary debug controls are supported"
+        },
+        "auditTrail": {
+          "type": "boolean",
+          "description": "Whether audit logging is available"
+        }
+      },
+      "required": ["multiTenancy", "performanceMetrics", "temporaryControls", "auditTrail"],
+      "additionalProperties": false
+    },
+    "security": {
+      "type": "object",
+      "properties": {
+        "level": {
+          "$ref": "../common/rdcp-common.json#/$defs/securityLevel"
+        },
+        "methods": {
+          "type": "array",
+          "items": {
+            "$ref": "../common/rdcp-common.json#/$defs/authMethod"
+          },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Supported authentication methods"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["discovery", "status", "control", "admin"]
+          },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Available permission scopes"
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether authentication is required"
+        },
+        "keyRotation": {
+          "type": "boolean",
+          "description": "Whether key rotation is supported"
+        },
+        "tokenRefresh": {
+          "type": "boolean",
+          "description": "Whether token refresh is supported"
+        }
+      },
+      "required": ["level", "methods", "required"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["protocol", "endpoints", "capabilities", "security"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "protocol": "rdcp/1.0",
+      "endpoints": {
+        "discovery": "/rdcp/v1/discovery",
+        "control": "/rdcp/v1/control", 
+        "status": "/rdcp/v1/status",
+        "health": "/rdcp/v1/health"
+      },
+      "capabilities": {
+        "multiTenancy": true,
+        "performanceMetrics": true,
+        "temporaryControls": true,
+        "auditTrail": true
+      },
+      "security": {
+        "level": "standard",
+        "methods": ["bearer"],
+        "scopes": ["discovery", "status", "control"],
+        "required": true,
+        "keyRotation": false,
+        "tokenRefresh": true
+      }
+    }
+  ]
+}

--- a/schema/v1/endpoints/status-response.json
+++ b/schema/v1/endpoints/status-response.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/endpoints/status-response.json",
+  "title": "RDCP Status Response v1.0",
+  "description": "Response schema for GET /rdcp/v1/status endpoint", 
+  "type": "object",
+  "properties": {
+    "protocol": {
+      "$ref": "../common/rdcp-common.json#/$defs/protocolVersion"
+    },
+    "timestamp": {
+      "$ref": "../common/rdcp-common.json#/$defs/timestamp"
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Whether debug system is globally enabled"
+    },
+    "categories": {
+      "type": "object",
+      "patternProperties": {
+        "^[A-Z][A-Z0-9_]*$": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Current enabled/disabled state of each category"
+    },
+    "performance": {
+      "$ref": "../common/rdcp-common.json#/$defs/metrics"
+    },
+    "tenant": {
+      "$ref": "../common/rdcp-common.json#/$defs/tenantContext"
+    }
+  },
+  "required": ["protocol", "timestamp", "enabled", "categories"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "protocol": "rdcp/1.0",
+      "timestamp": "2025-09-17T10:30:00Z", 
+      "enabled": true,
+      "categories": {
+        "DATABASE": true,
+        "API_ROUTES": false
+      },
+      "performance": {
+        "callsTotal": 45678,
+        "callsPerSecond": 2.3
+      }
+    }
+  ]
+}

--- a/schema/v1/responses/error.json
+++ b/schema/v1/responses/error.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://mojoatomic.github.io/rdcp-protocol/schema/v1/responses/error.json",
+  "title": "RDCP Error Response v1.0",
+  "description": "Standard error response format for RDCP protocol operations",
+  "type": "object",
+  "properties": {
+    "error": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "$ref": "../common/rdcp-common.json#/$defs/rdcpErrorCode"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable error message"
+        },
+        "details": {
+          "type": "object",
+          "description": "Additional error context and details",
+          "additionalProperties": true
+        },
+        "protocol": {
+          "$ref": "../common/rdcp-common.json#/$defs/protocolVersion"
+        }
+      },
+      "required": ["code", "message", "protocol"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["error"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "error": {
+        "code": "RDCP_VALIDATION_ERROR",
+        "message": "Request validation failed",
+        "details": {
+          "field": "categories",
+          "reason": "Invalid category name format"
+        },
+        "protocol": "rdcp/1.0"
+      }
+    },
+    {
+      "error": {
+        "code": "RDCP_AUTH_REQUIRED",
+        "message": "Authentication required",
+        "protocol": "rdcp/1.0"
+      }
+    }
+  ]
+}

--- a/scripts/validate-schemas.js
+++ b/scripts/validate-schemas.js
@@ -1,0 +1,70 @@
+/* RDCP Protocol - JSON Schema validation (draft-07)
+   Plain text output suitable for CI and local use. */
+
+const fs = require('fs')
+const path = require('path')
+const Ajv = require('ajv')
+const addFormats = require('ajv-formats')
+const draft7Meta = require('ajv/dist/refs/json-schema-draft-07.json')
+
+function main() {
+  const repoRoot = process.cwd()
+  const ajv = new Ajv({ allErrors: true, strict: false })
+  try {
+    if (!ajv.getSchema('http://json-schema.org/draft-07/schema')) {
+      ajv.addMetaSchema(draft7Meta)
+    }
+  } catch (_) {}
+  addFormats(ajv)
+
+  // Preload common schema using its canonical $id to satisfy $ref
+  const commonPath = path.join(repoRoot, 'schema/v1/common/rdcp-common.json')
+  const commonSchema = JSON.parse(fs.readFileSync(commonPath, 'utf8'))
+  ajv.addSchema(
+    commonSchema,
+    'https://mojoatomic.github.io/rdcp-protocol/schema/v1/common/rdcp-common.json'
+  )
+  console.log('Loaded common schema')
+
+  const files = [
+    'schema/v1/responses/error.json',
+    'schema/v1/endpoints/protocol-discovery.json',
+    'schema/v1/endpoints/control-request.json',
+    'schema/v1/endpoints/control-response.json',
+    'schema/v1/endpoints/discovery-response.json',
+    'schema/v1/endpoints/status-response.json',
+    'schema/v1/endpoints/health-response.json'
+  ]
+
+  for (const rel of files) {
+    const full = path.join(repoRoot, rel)
+    const schema = JSON.parse(fs.readFileSync(full, 'utf8'))
+
+    let validate
+    try {
+      validate = ajv.compile(schema)
+      console.log(`Compiled: ${rel}`)
+    } catch (err) {
+      console.error(`Compile error in ${rel}: ${err.message}`)
+      process.exit(1)
+    }
+
+    if (Array.isArray(schema.examples)) {
+      schema.examples.forEach((example, i) => {
+        const ok = validate(example)
+        if (!ok) {
+          console.error(`Example ${i + 1} failed in ${rel}`)
+          console.error(validate.errors)
+          process.exit(1)
+        }
+      })
+      console.log(`Examples valid: ${rel}`)
+    }
+  }
+
+  console.log('All schemas compiled and examples validated')
+}
+
+if (require.main === module) {
+  main()
+}


### PR DESCRIPTION
Add discoverable documentation pages for JSON Schemas under docs/schemas/ and update mkdocs navigation.

- Overview page and per-schema pages
- Links to canonical schema URLs and repo locations
- Sample payloads for each endpoint and error response

This makes schemas visible and usable to implementers via the published site.