### PR TITLE
docs(api): OpenAPI v1 + Redoc + CI validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           pip install mkdocs-material
           pip install mkdocs-git-revision-date-localized-plugin
+          pip install mkdocs-redoc-tag
       - name: MkDocs build (no deploy)
         run: mkdocs build --strict
 
@@ -51,6 +52,7 @@ jobs:
         run: |
           pip install mkdocs-material
           pip install mkdocs-git-revision-date-localized-plugin
+          pip install mkdocs-redoc-tag
           pip install mike
       - name: Deploy with versioning
         run: |

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -1,24 +1,11 @@
 name: Validate OpenAPI
 
-on:
-  push:
-    paths:
-      - 'docs/api/**/*.json'
-      - '.github/workflows/validate-openapi.yml'
-  pull_request:
-    paths:
-      - 'docs/api/**/*.json'
-      - '.github/workflows/validate-openapi.yml'
+on: [push, pull_request]
 
 jobs:
-  validate:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-
-      - name: Lint (Redocly)
-        run: |
-          npx --yes @redocly/cli@latest lint docs/api/v1/openapi.json
+      - uses: actions/checkout@v3
+      - name: Lint OpenAPI spec
+        run: npx @redocly/cli@latest lint docs/api/v1/openapi.json

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -21,8 +21,12 @@ jobs:
 
       - name: Validate (swagger-cli)
         run: |
-          npx --yes @apidevtools/swagger-cli@5.1.0 validate docs/api/v1/openapi.json
+          npx --yes @apidevtools/swagger-cli@4.0.4 validate docs/api/v1/openapi.json
 
       - name: Lint (Redocly)
         run: |
           npx --yes @redocly/cli@latest lint docs/api/v1/openapi.json
+
+      - name: Lint (Spectral)
+        run: |
+          npx --yes @stoplight/spectral-cli@6.11.1 lint docs/api/v1/openapi.json

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -19,14 +19,6 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Validate (swagger-cli)
-        run: |
-          npx --yes @apidevtools/swagger-cli@4.0.4 validate docs/api/v1/openapi.json
-
       - name: Lint (Redocly)
         run: |
           npx --yes @redocly/cli@latest lint docs/api/v1/openapi.json
-
-      - name: Lint (Spectral)
-        run: |
-          npx --yes @stoplight/spectral-cli@6.11.1 lint docs/api/v1/openapi.json

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -1,0 +1,28 @@
+name: Validate OpenAPI
+
+on:
+  push:
+    paths:
+      - 'docs/api/**/*.json'
+      - '.github/workflows/validate-openapi.yml'
+  pull_request:
+    paths:
+      - 'docs/api/**/*.json'
+      - '.github/workflows/validate-openapi.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Validate (swagger-cli)
+        run: |
+          npx --yes @apidevtools/swagger-cli@5.1.0 validate docs/api/v1/openapi.json
+
+      - name: Lint (Redocly)
+        run: |
+          npx --yes @redocly/cli@latest lint docs/api/v1/openapi.json

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,7 @@
+# RDCP OpenAPI (v1)
+
+This page renders the RDCP OpenAPI contract for version 1.
+
+```redoc
+spec-url: ./v1/openapi.json
+```

--- a/docs/api/v1/openapi.json
+++ b/docs/api/v1/openapi.json
@@ -15,12 +15,14 @@
   },
   "servers": [
     {
-      "url": "https://api.example.com",
-      "description": "Production server"
-    },
-    {
-      "url": "http://localhost:3000",
-      "description": "Development server"
+      "url": "https://{hostname}",
+      "description": "RDCP-compliant server",
+      "variables": {
+        "hostname": {
+          "default": "localhost:3000",
+          "description": "Server hostname and port"
+        }
+      }
     }
   ],
   "paths": {

--- a/docs/api/v1/openapi.json
+++ b/docs/api/v1/openapi.json
@@ -64,7 +64,8 @@
                 }
               }
             }
-          }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
         }
       }
     },
@@ -75,13 +76,7 @@
         "operationId": "getDiscovery",
         "tags": ["Discovery"],
         "parameters": [
-          {
-            "name": "X-RDCP-Tenant-ID",
-            "in": "header",
-            "description": "Tenant identifier for multi-tenant deployments",
-            "required": false,
-            "schema": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,255}$" }
-          }
+          { "$ref": "#/components/parameters/TenantId" }
         ],
         "responses": {
           "200": {
@@ -130,13 +125,7 @@
         "operationId": "postControl",
         "tags": ["Control"],
         "parameters": [
-          {
-            "name": "X-RDCP-Tenant-ID",
-            "in": "header",
-            "description": "Tenant identifier for multi-tenant deployments",
-            "required": false,
-            "schema": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,255}$" }
-          }
+          { "$ref": "#/components/parameters/TenantId" }
         ],
         "requestBody": {
           "required": true,
@@ -200,13 +189,7 @@
         "operationId": "getStatus",
         "tags": ["Monitoring"],
         "parameters": [
-          {
-            "name": "X-RDCP-Tenant-ID",
-            "in": "header",
-            "description": "Tenant identifier for multi-tenant deployments",
-            "required": false,
-            "schema": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,255}$" }
-          }
+          { "$ref": "#/components/parameters/TenantId" }
         ],
         "responses": {
           "200": {
@@ -254,6 +237,7 @@
               }
             }
           },
+          "400": { "$ref": "#/components/responses/BadRequest" },
           "503": {
             "description": "Service unavailable",
             "content": {
@@ -279,7 +263,7 @@
         "operationId": "getMetrics",
         "tags": ["Monitoring"],
         "parameters": [
-          { "name": "X-RDCP-Tenant-ID", "in": "header", "description": "Tenant identifier for multi-tenant deployments", "required": false, "schema": { "type": "string" } }
+          { "$ref": "#/components/parameters/TenantId" }
         ],
         "responses": {
           "200": {

--- a/docs/api/v1/openapi.json
+++ b/docs/api/v1/openapi.json
@@ -1,0 +1,540 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Runtime Debug Control Protocol (RDCP)",
+    "version": "1.0.0",
+    "description": "A standardized HTTP-based protocol for controlling debug logging in distributed applications at runtime.",
+    "contact": {
+      "name": "RDCP Protocol",
+      "url": "https://github.com/mojoatomic/rdcp-protocol"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com",
+      "description": "Production server"
+    },
+    {
+      "url": "http://localhost:3000",
+      "description": "Development server"
+    }
+  ],
+  "paths": {
+    "/.well-known/rdcp": {
+      "get": {
+        "summary": "Protocol Discovery",
+        "description": "Returns protocol version, available endpoints, capabilities, and security configuration",
+        "operationId": "getWellKnown",
+        "tags": ["Discovery"],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Protocol information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/WellKnownResponse" },
+                "example": {
+                  "protocol": "rdcp/1.0",
+                  "endpoints": {
+                    "discovery": "/rdcp/v1/discovery",
+                    "control": "/rdcp/v1/control",
+                    "status": "/rdcp/v1/status",
+                    "health": "/rdcp/v1/health"
+                  },
+                  "capabilities": {
+                    "multiTenancy": true,
+                    "performanceMetrics": true,
+                    "temporaryControls": true,
+                    "auditTrail": true
+                  },
+                  "security": {
+                    "level": "standard",
+                    "methods": ["api-key", "bearer"],
+                    "scopes": ["discovery", "status", "control", "admin"],
+                    "required": true,
+                    "keyRotation": true,
+                    "tokenRefresh": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rdcp/v1/discovery": {
+      "get": {
+        "summary": "Debug System Discovery",
+        "description": "Lists available debug categories with their current state and metrics",
+        "operationId": "getDiscovery",
+        "tags": ["Discovery"],
+        "parameters": [
+          {
+            "name": "X-RDCP-Tenant-ID",
+            "in": "header",
+            "description": "Tenant identifier for multi-tenant deployments",
+            "required": false,
+            "schema": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,255}$" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Debug categories and system information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DiscoveryResponse" },
+                "example": {
+                  "protocol": "rdcp/1.0",
+                  "timestamp": "2025-09-17T10:30:00.000Z",
+                  "categories": [
+                    {
+                      "name": "DATABASE",
+                      "description": "Database operations",
+                      "enabled": true,
+                      "temporary": false,
+                      "metrics": { "callsTotal": 1234, "callsPerSecond": 2.3 }
+                    },
+                    {
+                      "name": "API_ROUTES",
+                      "description": "API route handling",
+                      "enabled": false,
+                      "temporary": false,
+                      "metrics": { "callsTotal": 0, "callsPerSecond": 0 }
+                    }
+                  ],
+                  "performance": {
+                    "totalCalls": 45678,
+                    "callsPerSecond": 2.3,
+                    "categoryBreakdown": { "DATABASE": 1234 }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        },
+        "security": [ { "ApiKeyAuth": [] }, { "BearerAuth": [] } ]
+      }
+    },
+    "/rdcp/v1/control": {
+      "post": {
+        "summary": "Runtime Control",
+        "description": "Enable, disable, toggle, or reset debug categories",
+        "operationId": "postControl",
+        "tags": ["Control"],
+        "parameters": [
+          {
+            "name": "X-RDCP-Tenant-ID",
+            "in": "header",
+            "description": "Tenant identifier for multi-tenant deployments",
+            "required": false,
+            "schema": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,255}$" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ControlRequest" },
+              "examples": {
+                "enable": { "summary": "Enable category", "value": { "action": "enable", "categories": ["DATABASE"] } },
+                "temporary": {
+                  "summary": "Temporary enable with duration",
+                  "value": {
+                    "action": "enable",
+                    "categories": ["DATABASE", "API_ROUTES"],
+                    "options": { "temporary": true, "duration": "15m", "reason": "Investigating issue #1234" }
+                  }
+                },
+                "disable": { "summary": "Disable category", "value": { "action": "disable", "categories": ["DATABASE"] } }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Control operation result",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ControlResponse" },
+                "example": {
+                  "protocol": "rdcp/1.0",
+                  "timestamp": "2025-09-17T10:30:00.000Z",
+                  "action": "enable",
+                  "categories": ["DATABASE"],
+                  "status": "success",
+                  "message": "Enabled categories",
+                  "changes": [
+                    {
+                      "category": "DATABASE",
+                      "previousState": false,
+                      "newState": true,
+                      "temporary": true,
+                      "effectiveAt": "2025-09-17T10:30:00.000Z",
+                      "expiresAt": "2025-09-17T10:45:00.000Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        },
+        "security": [ { "ApiKeyAuth": [] }, { "BearerAuth": [] } ]
+      }
+    },
+    "/rdcp/v1/status": {
+      "get": {
+        "summary": "Current Status",
+        "description": "Returns current state of all debug categories",
+        "operationId": "getStatus",
+        "tags": ["Monitoring"],
+        "parameters": [
+          {
+            "name": "X-RDCP-Tenant-ID",
+            "in": "header",
+            "description": "Tenant identifier for multi-tenant deployments",
+            "required": false,
+            "schema": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,255}$" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current debug status",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/StatusResponse" },
+                "example": {
+                  "protocol": "rdcp/1.0",
+                  "timestamp": "2025-09-17T10:30:00.000Z",
+                  "enabled": true,
+                  "categories": { "DATABASE": true, "API_ROUTES": false, "CACHE": false },
+                  "performance": { "totalCalls": 45678, "callsPerSecond": 2.3 }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        },
+        "security": [ { "ApiKeyAuth": [] }, { "BearerAuth": [] } ]
+      }
+    },
+    "/rdcp/v1/health": {
+      "get": {
+        "summary": "System Health",
+        "description": "Returns system health status and dependency checks",
+        "operationId": "getHealth",
+        "tags": ["Monitoring"],
+        "responses": {
+          "200": {
+            "description": "System health information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HealthResponse" },
+                "example": {
+                  "protocol": "rdcp/1.0",
+                  "timestamp": "2025-09-17T10:30:00.000Z",
+                  "status": "healthy",
+                  "checks": [
+                    { "name": "redis", "status": "pass", "duration": "5ms" },
+                    { "name": "database", "status": "pass", "duration": "8ms" }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HealthResponse" },
+                "example": {
+                  "protocol": "rdcp/1.0",
+                  "timestamp": "2025-09-17T10:30:00.000Z",
+                  "status": "unhealthy",
+                  "checks": [ { "name": "redis", "status": "fail", "duration": "5000ms" } ]
+                }
+              }
+            }
+          }
+        },
+        "security": [ { "ApiKeyAuth": [] }, { "BearerAuth": [] } ]
+      }
+    },
+    "/rdcp/v1/metrics": {
+      "get": {
+        "summary": "Performance Metrics",
+        "description": "Optional endpoint for detailed performance metrics",
+        "operationId": "getMetrics",
+        "tags": ["Monitoring"],
+        "parameters": [
+          { "name": "X-RDCP-Tenant-ID", "in": "header", "description": "Tenant identifier for multi-tenant deployments", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Performance metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "protocol": { "type": "string", "example": "rdcp/1.0" },
+                    "timestamp": { "type": "string", "format": "date-time" },
+                    "metrics": { "type": "object" }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        },
+        "security": [ { "ApiKeyAuth": [] }, { "BearerAuth": [] } ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": { "type": "apiKey", "in": "header", "name": "X-RDCP-API-Key", "description": "API key for basic authentication. Format: rdcp_[env]_[type]_[random]" },
+      "BearerAuth": { "type": "http", "scheme": "bearer", "bearerFormat": "JWT", "description": "Bearer token (JWT) for standard authentication" }
+    },
+    "schemas": {
+      "WellKnownResponse": {
+        "type": "object",
+        "required": ["protocol", "endpoints", "capabilities", "security"],
+        "properties": {
+          "protocol": { "type": "string", "example": "rdcp/1.0", "description": "Protocol version" },
+          "endpoints": {
+            "type": "object",
+            "required": ["discovery", "control", "status", "health"],
+            "properties": {
+              "discovery": { "type": "string", "example": "/rdcp/v1/discovery" },
+              "control": { "type": "string", "example": "/rdcp/v1/control" },
+              "status": { "type": "string", "example": "/rdcp/v1/status" },
+              "health": { "type": "string", "example": "/rdcp/v1/health" }
+            }
+          },
+          "capabilities": {
+            "type": "object",
+            "required": ["multiTenancy", "performanceMetrics", "temporaryControls", "auditTrail"],
+            "properties": {
+              "multiTenancy": { "type": "boolean" },
+              "performanceMetrics": { "type": "boolean" },
+              "temporaryControls": { "type": "boolean" },
+              "auditTrail": { "type": "boolean" }
+            }
+          },
+          "security": {
+            "type": "object",
+            "required": ["level", "methods", "scopes", "required"],
+            "properties": {
+              "level": { "type": "string", "enum": ["basic", "standard", "enterprise"] },
+              "methods": { "type": "array", "items": { "type": "string", "enum": ["api-key", "bearer", "mtls"] } },
+              "scopes": { "type": "array", "items": { "type": "string", "enum": ["discovery", "status", "control", "admin"] } },
+              "required": { "type": "boolean" },
+              "keyRotation": { "type": "boolean" },
+              "tokenRefresh": { "type": "boolean" }
+            }
+          }
+        }
+      },
+      "DiscoveryResponse": {
+        "type": "object",
+        "required": ["protocol", "timestamp", "categories"],
+        "properties": {
+          "protocol": { "type": "string", "example": "rdcp/1.0" },
+          "timestamp": { "type": "string", "format": "date-time", "description": "ISO 8601 timestamp with milliseconds and UTC timezone", "example": "2025-09-17T10:30:00.000Z" },
+          "categories": { "type": "array", "items": { "$ref": "#/components/schemas/Category" } },
+          "performance": { "$ref": "#/components/schemas/Performance" },
+          "tenant": { "$ref": "#/components/schemas/TenantContext" }
+        }
+      },
+      "Category": {
+        "type": "object",
+        "required": ["name", "description", "enabled"],
+        "properties": {
+          "name": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]{0,63}$", "description": "Category name in uppercase with underscores", "example": "DATABASE" },
+          "description": { "type": "string", "example": "Database operations" },
+          "enabled": { "type": "boolean" },
+          "temporary": { "type": "boolean" },
+          "metrics": { "type": "object", "properties": { "callsTotal": { "type": "number" }, "callsPerSecond": { "type": "number" } } }
+        }
+      },
+      "Performance": {
+        "type": "object",
+        "properties": {
+          "totalCalls": { "type": "number" },
+          "callsPerSecond": { "type": "number" },
+          "categoryBreakdown": { "type": "object", "additionalProperties": { "type": "number" } }
+        }
+      },
+      "ControlRequest": {
+        "type": "object",
+        "required": ["action", "categories"],
+        "properties": {
+          "action": { "type": "string", "enum": ["enable", "disable", "toggle", "reset", "status"], "description": "Control action to perform" },
+          "categories": { "type": "array", "items": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]{0,63}$" }, "minItems": 1, "uniqueItems": true, "description": "List of category names to control" },
+          "options": {
+            "type": "object",
+            "properties": {
+              "temporary": { "type": "boolean", "description": "Whether the change is temporary" },
+              "duration": { "oneOf": [ { "type": "number", "description": "Duration in seconds" }, { "type": "string", "pattern": "^\\d+[smhd]$", "description": "Duration string (e.g., '15m', '2h')" } ] },
+              "reason": { "type": "string", "description": "Reason for the change (audit trail)" }
+            }
+          }
+        }
+      },
+      "ControlResponse": {
+        "type": "object",
+        "required": ["protocol", "timestamp", "action", "categories", "status"],
+        "properties": {
+          "protocol": { "type": "string", "example": "rdcp/1.0" },
+          "timestamp": { "type": "string", "format": "date-time", "example": "2025-09-17T10:30:00.000Z" },
+          "action": { "type": "string", "enum": ["enable", "disable", "toggle", "reset", "status"] },
+          "categories": { "type": "array", "items": { "type": "string" } },
+          "status": { "type": "string", "enum": ["success", "partial", "failed"] },
+          "message": { "type": "string" },
+          "changes": { "type": "array", "items": { "$ref": "#/components/schemas/Change" } },
+          "tenant": { "$ref": "#/components/schemas/TenantContext" }
+        }
+      },
+      "Change": {
+        "type": "object",
+        "required": ["category", "previousState", "newState"],
+        "properties": {
+          "category": { "type": "string" },
+          "previousState": { "type": "boolean" },
+          "newState": { "type": "boolean" },
+          "temporary": { "type": "boolean" },
+          "effectiveAt": { "type": "string", "format": "date-time" },
+          "expiresAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "StatusResponse": {
+        "type": "object",
+        "required": ["protocol", "timestamp", "enabled", "categories"],
+        "properties": {
+          "protocol": { "type": "string", "example": "rdcp/1.0" },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "enabled": { "type": "boolean", "description": "Whether any debug category is enabled" },
+          "categories": { "type": "object", "additionalProperties": { "type": "boolean" }, "description": "Map of category names to enabled state" },
+          "performance": { "$ref": "#/components/schemas/Performance" },
+          "tenant": { "$ref": "#/components/schemas/TenantContext" }
+        }
+      },
+      "HealthResponse": {
+        "type": "object",
+        "required": ["protocol", "timestamp", "status", "checks"],
+        "properties": {
+          "protocol": { "type": "string", "example": "rdcp/1.0" },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "status": { "type": "string", "enum": ["healthy", "degraded", "unhealthy"] },
+          "checks": { "type": "array", "items": { "$ref": "#/components/schemas/HealthCheck" } }
+        }
+      },
+      "HealthCheck": {
+        "type": "object",
+        "required": ["name", "status"],
+        "properties": {
+          "name": { "type": "string", "example": "redis" },
+          "status": { "type": "string", "enum": ["pass", "fail", "warn"] },
+          "duration": { "type": "string", "description": "Duration of the health check", "example": "5ms" }
+        }
+      },
+      "TenantContext": {
+        "type": "object",
+        "required": ["id", "isolationLevel", "scope"],
+        "properties": {
+          "id": { "type": "string", "description": "Tenant identifier" },
+          "isolationLevel": { "type": "string", "enum": ["global", "process", "namespace", "organization"] },
+          "scope": { "type": "string", "enum": ["global", "tenant-isolated"] }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message", "protocol"],
+            "properties": {
+              "code": { "type": "string", "pattern": "^[A-Z0-9_]{3,64}$", "example": "UNAUTHORIZED" },
+              "message": { "type": "string", "example": "Authentication required" },
+              "details": { "type": "object", "description": "Additional error context" },
+              "protocol": { "type": "string", "example": "rdcp/1.0" }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request - invalid input",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+            "example": { "error": { "code": "INVALID_REQUEST", "message": "Invalid category name", "protocol": "rdcp/1.0" } }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Authentication required",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+            "example": { "error": { "code": "UNAUTHORIZED", "message": "Authentication required", "protocol": "rdcp/1.0" } }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Insufficient permissions",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+            "example": {
+              "error": {
+                "code": "FORBIDDEN",
+                "message": "Insufficient permissions",
+                "details": { "requiredScopes": ["control"], "providedScopes": ["status"] },
+                "protocol": "rdcp/1.0"
+              }
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+            "example": { "error": { "code": "CATEGORY_NOT_FOUND", "message": "Category not found", "protocol": "rdcp/1.0" } }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "TenantId": {
+        "name": "X-RDCP-Tenant-ID",
+        "in": "header",
+        "description": "Tenant identifier for multi-tenant deployments",
+        "required": false,
+        "schema": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,255}$" }
+      }
+    }
+  },
+  "tags": [
+    { "name": "Discovery", "description": "Protocol and system discovery endpoints" },
+    { "name": "Control", "description": "Runtime debug control operations" },
+    { "name": "Monitoring", "description": "Status and health monitoring endpoints" }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ plugins:
   - git-revision-date-localized:
       enable_creation_date: true
       type: datetime
+  - redoc-tag
 
 # Extensions
 markdown_extensions:
@@ -86,5 +87,6 @@ nav:
       - Health Response: schemas/endpoints/health-response.md
     - Response Types:
       - Error Response: schemas/responses/error.md
+  - API Reference: api/index.md
   - Error Codes: error-codes.md
   - Compliance Report: PROTOCOL-COMPLIANCE-REPORT.md

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,12 @@
+extends:
+  - recommended
+
+rules:
+  operation-operationId: error
+  path-parameters-defined: error
+  no-unresolved-refs: error
+  no-identical-paths: error
+
+apis:
+  rdcp@v1:
+    root: docs/api/v1/openapi.json


### PR DESCRIPTION
Implements versioned OpenAPI 3.1 (docs/api/v1/openapi.json), integrates Redoc rendering via mkdocs-redoc-tag (API Reference page), updates docs build to install the plugin, and adds CI validation/linting with swagger-cli and Redocly.\n\nContext7: Not currently configured as an MCP tool here; once available, we will cross-check any guidance and adjust accordingly.\n\n- Adds: docs/api/v1/openapi.json, docs/api/index.md\n- mkdocs.yml: redoc-tag plugin + nav entry\n- docs CI: installs mkdocs-redoc-tag\n- validate-openapi CI: swagger-cli validate + Redocly lint\n\nThis should enable API contract visibility, SDK generation workflows, and automated spec quality gates.