### PR TITLE
chore(pages): add /api redirect to /latest/api/ in deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,3 +58,23 @@ jobs:
         run: |
           mike deploy --push --update-aliases 1.0 latest
           mike set-default --push latest
+
+      - name: Add /api redirect to /latest/api/
+        run: |
+          git fetch origin gh-pages:gh-pages
+          git checkout gh-pages
+          mkdir -p api
+          cat > api/index.html <<'REDIR'
+          <!doctype html>
+          <html>
+            <head>
+              <meta http-equiv="refresh" content="0; url=../latest/api/" />
+              <link rel="canonical" href="../latest/api/" />
+              <meta name="robots" content="noindex" />
+            </head>
+            <body>Redirecting to latest API docs…</body>
+          </html>
+          REDIR
+          git add api/index.html
+          git commit -m 'chore(pages): add /api redirect to /latest/api/' || true
+          git push origin gh-pages


### PR DESCRIPTION
Adds a post-deploy step to gh-pages that writes api/index.html with a meta refresh redirect to /latest/api/. This fixes 404 on /api/ and makes the API URL stable.\n\nUses single-commit squash merge.