### PR TITLE
docs(home): fix API Reference link to version-aware path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ All RDCP-compliant implementations must expose these endpoints:
 
 ## Documentation Structure
 
-- **[API Reference](/api/)** - Interactive OpenAPI (v1) with try-it examples
+- **[API Reference](api/)** - Interactive OpenAPI (v1) with try-it examples
 - **[Protocol Specification](rdcp-protocol-specification.md)** - Complete technical specification
 - **[Implementation Guide](rdcp-implementation-guide.md)** - Step-by-step implementation instructions
 - **[Protocol Schemas](protocol-schemas.md)** - JSON schema definitions


### PR DESCRIPTION
Use a relative link (api/) on the homepage to avoid absolute root path (/api/) resolving to mojoatomic.github.io/api/. This ensures links work for latest and versioned docs.