### PR TITLE
docs(api): add Apache-2.0 license badge and note on API landing

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,7 @@
 # API Documentation
 
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+
 RDCP provides two ways to explore the API:
 
 ## [API Reference](reference.md)
@@ -9,3 +11,7 @@ Clean, readable documentation of all endpoints, schemas, and responses.
 Interactive testing environment - try API calls directly from your browser.
 
 Both views use the same OpenAPI specification: [openapi.json](v1/openapi.json)
+
+---
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -2,5 +2,4 @@
 
 ```redoc
 spec-url: ./v1/openapi.json
-hide-download-button: true
 ```

--- a/docs/api/v1/openapi.json
+++ b/docs/api/v1/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Runtime Debug Control Protocol (RDCP)",
     "version": "1.0.0",
-    "description": "A standardized HTTP-based protocol for controlling debug logging in distributed applications at runtime.",
+    "description": "A standardized HTTP-based protocol for controlling debug logging in distributed applications at runtime.\n\nCopyright 2025 Doug Fennell/rdcp.dev\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0",
     "contact": {
       "name": "RDCP Protocol",
       "url": "https://github.com/mojoatomic/rdcp-protocol"


### PR DESCRIPTION
Adds a small Apache-2.0 badge and a license note to the API landing page (docs/api/index.md).