### PR TITLE
docs(api): fix Reference rendering (use HTML tag)

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,5 +1,3 @@
 # API Reference
 
-```redoc
-spec-url: ./v1/openapi.json
-```
+<redoc spec-url="./v1/openapi.json"></redoc>


### PR DESCRIPTION
Switch Reference page to use <redoc> HTML tag for consistent rendering with mkdocs-redoc-tag.