### PR TITLE
docs: fix Redoc embed and strict link

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,3 +1,5 @@
 # API Reference
 
-<redoc spec-url="../v1/openapi.json"></redoc>
+```redoc
+spec-url: ../v1/openapi.json
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ All RDCP-compliant implementations must expose these endpoints:
 
 ## Documentation Structure
 
-- **[API Reference](api/)** - Interactive OpenAPI (v1) with try-it examples
+- **[API Reference](api/index.md)** - Interactive OpenAPI (v1) with try-it examples
 - **[Protocol Specification](rdcp-protocol-specification.md)** - Complete technical specification
 - **[Implementation Guide](rdcp-implementation-guide.md)** - Step-by-step implementation instructions
 - **[Protocol Schemas](protocol-schemas.md)** - JSON schema definitions


### PR DESCRIPTION
Redoc Reference now uses fenced redoc tag with spec-url ../v1/openapi.json (plugin picks it up and passes to iframe).\nFix homepage link to api/index.md to avoid strict-mode warning.