### PR TITLE
docs/compliance kit v1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         run: mkdocs build --strict
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-compliance-kit.yml
+++ b/.github/workflows/validate-compliance-kit.yml
@@ -1,0 +1,28 @@
+name: Validate Compliance Kit
+
+on:
+  push:
+    paths:
+      - 'compliance-kit/**'
+      - 'schema/**'
+      - 'scripts/validate-fixtures.js'
+  pull_request:
+    paths:
+      - 'compliance-kit/**'
+      - 'schema/**'
+      - 'scripts/validate-fixtures.js'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          npm init -y
+          npm i ajv ajv-formats
+      - name: Validate fixtures against JSON Schemas
+        run: node scripts/validate-fixtures.js

--- a/compliance-kit/v1.0/MANIFEST.json
+++ b/compliance-kit/v1.0/MANIFEST.json
@@ -1,0 +1,83 @@
+{
+  "version": "1.0",
+  "tests": [
+    {
+      "id": "well-known-200",
+      "name": "Well-known discovery returns protocol info",
+      "request": { "method": "GET", "path": "/.well-known/rdcp" },
+      "expect": { "status": 200, "schema": "schema/v1/endpoints/protocol-discovery.json" }
+    },
+    {
+      "id": "discovery-200",
+      "name": "Discovery lists categories",
+      "request": { "method": "GET", "path": "/rdcp/v1/discovery", "headers": { "X-RDCP-Tenant-ID": "TENANT_ID" } },
+      "expect": { "status": 200, "schema": "schema/v1/endpoints/discovery-response.json" }
+    },
+    {
+      "id": "discovery-tenant-invalid-400",
+      "name": "Discovery rejects invalid tenant header",
+      "request": { "method": "GET", "path": "/rdcp/v1/discovery", "headers": { "X-RDCP-Tenant-ID": "tenant with spaces" } },
+      "expect": { "status": 400, "schema": "schema/v1/responses/error.json" }
+    },
+    {
+      "id": "control-enable-200",
+      "name": "Control enable DATABASE succeeds",
+      "request": { "method": "POST", "path": "/rdcp/v1/control", "bodyFixture": "fixtures/control/request-enable-valid.json" },
+      "expect": { "status": 200, "schema": "schema/v1/endpoints/control-response.json" }
+    },
+    {
+      "id": "control-invalid-action-400",
+      "name": "Control invalid action rejected",
+      "request": { "method": "POST", "path": "/rdcp/v1/control", "bodyFixture": "fixtures/control/request-invalid-action.json" },
+      "expect": { "status": 400, "schema": "schema/v1/responses/error.json" }
+    },
+    {
+      "id": "control-invalid-category-400",
+      "name": "Control invalid category rejected",
+      "request": { "method": "POST", "path": "/rdcp/v1/control", "bodyFixture": "fixtures/control/request-invalid-category.json" },
+      "expect": { "status": 400, "schema": "schema/v1/responses/error.json" }
+    },
+    {
+      "id": "control-missing-categories-400",
+      "name": "Control missing categories rejected",
+      "request": { "method": "POST", "path": "/rdcp/v1/control", "bodyFixture": "fixtures/control/request-missing-categories.json" },
+      "expect": { "status": 400, "schema": "schema/v1/responses/error.json" }
+    },
+    {
+      "id": "status-200",
+      "name": "Status endpoint returns current states",
+      "request": { "method": "GET", "path": "/rdcp/v1/status" },
+      "expect": { "status": 200, "schema": "schema/v1/endpoints/status-response.json" }
+    },
+    {
+      "id": "errors-401",
+      "name": "Protected endpoints require auth",
+      "request": { "method": "GET", "path": "/rdcp/v1/status", "headers": { "Authorization": "" } },
+      "expect": { "status": 401, "schema": "schema/v1/responses/error.json" }
+    },
+    {
+      "id": "errors-403",
+      "name": "Insufficient scope rejected",
+      "request": { "method": "POST", "path": "/rdcp/v1/control" },
+      "expect": { "status": 403, "schema": "schema/v1/responses/error.json" }
+    },
+    {
+      "id": "errors-404",
+      "name": "Unknown category returns 404",
+      "request": { "method": "POST", "path": "/rdcp/v1/control", "bodyFixture": "fixtures/control/request-invalid-category.json" },
+      "expect": { "status": 404, "schema": "schema/v1/responses/error.json" }
+    }
+  ],
+  "sequences": [
+    {
+      "id": "enable-and-verify",
+      "name": "Enable DATABASE then verify via status",
+      "steps": [
+        { "use": "control-enable-200" },
+        { "request": { "method": "GET", "path": "/rdcp/v1/status" },
+          "assert": { "status": 200, "schema": "schema/v1/endpoints/status-response.json", "bodyContains": { "categories": { "DATABASE": true } } }
+        }
+      ]
+    }
+  ]
+}

--- a/compliance-kit/v1.0/README.md
+++ b/compliance-kit/v1.0/README.md
@@ -1,0 +1,49 @@
+# RDCP Compliance Kit (v1.0)
+
+This kit helps implementers validate conformance to the RDCP v1.0 protocol using portable JSON fixtures and curl. It is language‑agnostic and versioned with the protocol.
+
+What you can do now (Phase 1)
+- Validate that example responses conform to the published JSON Schemas
+- Send critical positive and negative requests to your server using curl
+- Run a simple behavior sequence: enable a category then verify status
+
+Setup
+- Choose your base URL: export BASE_URL=https://localhost:3000
+- Choose auth (one):
+  - export RDCP_API_KEY=rdcp_dev_basic_XXXX   # API key
+  - or export RDCP_BEARER_TOKEN=...           # Bearer token (JWT)
+- Optional tenant: export TENANT_ID=acme-dev
+
+Quick checks (curl)
+```bash
+# Well‑known
+curl -fsS -H 'Accept: application/json' "$BASE_URL/.well-known/rdcp" | jq .
+
+# Discovery
+curl -fsS -H 'Accept: application/json' -H "X-RDCP-Tenant-ID: ${TENANT_ID:-acme-dev}" \
+  "$BASE_URL/rdcp/v1/discovery" | jq .
+
+# Control enable
+curl -fsS -X POST "$BASE_URL/rdcp/v1/control" \
+  -H 'Content-Type: application/json' \
+  -H "X-RDCP-API-Key: ${RDCP_API_KEY}" \
+  --data @fixtures/control/request-enable-valid.json | jq .
+
+# Status
+curl -fsS -H 'Accept: application/json' -H "X-RDCP-API-Key: ${RDCP_API_KEY}" \
+  "$BASE_URL/rdcp/v1/status" | jq .
+```
+
+Behavior sequence: enable‑and‑verify
+- See sequences/enable-and-verify.json for the two calls and expected outcome (DATABASE=true in status).
+
+Validating fixtures (CI or local)
+- This repo includes a workflow to validate fixtures against schemas.
+- Locally, run:
+```bash
+node scripts/validate-fixtures.js
+```
+
+Notes
+- Fixtures are examples; server responses may include additional fields. Conformance focuses on status codes and required fields/shapes.
+- Negative cases check that invalid inputs are rejected with appropriate error status and ErrorResponse envelope.

--- a/compliance-kit/v1.0/README.md
+++ b/compliance-kit/v1.0/README.md
@@ -37,12 +37,28 @@ curl -fsS -H 'Accept: application/json' -H "X-RDCP-API-Key: ${RDCP_API_KEY}" \
 Behavior sequence: enable‑and‑verify
 - See sequences/enable-and-verify.json for the two calls and expected outcome (DATABASE=true in status).
 
-Validating fixtures (CI or local)
-- This repo includes a workflow to validate fixtures against schemas.
-- Locally, run:
+## Running Validation Locally
 ```bash
+# Install dependencies
+npm install
+
+# Validate all fixtures
 node scripts/validate-fixtures.js
 ```
+If validation fails, check:
+- Fixture conforms to schema structure
+- Error codes match defined values in error-codes.md
+- Field names match exactly (e.g., callsTotal not totalCalls)
+
+**Skip:**
+- Detailed AJV configuration docs (implementation detail)
+- JSON linting workflow (nice-to-have, not essential)
+- Heavy CONTRIBUTING guide (you don't have external contributors yet)
+
+**The compliance kit needs:**
+- README with "how to use" (curl examples, validation)
+- MANIFEST.json explaining test expectations
+- Clear fixture organization
 
 Notes
 - Fixtures are examples; server responses may include additional fields. Conformance focuses on status codes and required fields/shapes.

--- a/compliance-kit/v1.0/assertions.md
+++ b/compliance-kit/v1.0/assertions.md
@@ -1,0 +1,37 @@
+# Assertions and Coverage (v1.0)
+
+This document explains what each fixture/sequence is asserting against the RDCP v1.0 specification.
+
+## Endpoints
+
+- `/.well-known/rdcp` → WellKnownResponse
+  - Asserts required fields: protocol, endpoints, capabilities, security
+- `/rdcp/v1/discovery` → DiscoveryResponse
+  - Asserts timestamp format, categories array, performance object
+  - Negative: invalid `X-RDCP-Tenant-ID` fails with 400 ErrorResponse
+- `/rdcp/v1/control` → ControlRequest/ControlResponse
+  - Valid: action=enable + categories=["DATABASE"] returns 200 ControlResponse
+  - Negative: invalid action, invalid category pattern, missing categories → 400 ErrorResponse
+- `/rdcp/v1/status` → StatusResponse
+  - Asserts enabled flag and categories map
+
+## Behavior sequence
+
+- `enable-and-verify`:
+  1) POST control (enable DATABASE)
+  2) GET status → categories.DATABASE === true
+
+## Error conditions
+
+- 401 Unauthorized: protected endpoints with missing/invalid auth
+- 403 Forbidden: insufficient scopes/permissions
+- 404 Not Found: unknown category
+
+## Schema references
+
+- Common: schema/v1/common/rdcp-common.json
+- Well-known: schema/v1/endpoints/protocol-discovery.json
+- Discovery: schema/v1/endpoints/discovery-response.json
+- Control (request/response): schema/v1/endpoints/control-request.json, control-response.json
+- Status: schema/v1/endpoints/status-response.json
+- Error envelope: schema/v1/responses/error.json

--- a/compliance-kit/v1.0/fixtures/control/request-enable-valid.json
+++ b/compliance-kit/v1.0/fixtures/control/request-enable-valid.json
@@ -1,0 +1,1 @@
+{"action":"enable","categories":["DATABASE"],"options":{"temporary":true,"duration":"15m","reason":"Investigating issue"}}

--- a/compliance-kit/v1.0/fixtures/control/request-invalid-action.json
+++ b/compliance-kit/v1.0/fixtures/control/request-invalid-action.json
@@ -1,0 +1,1 @@
+{"action":"turn_on","categories":["DATABASE"]}

--- a/compliance-kit/v1.0/fixtures/control/request-invalid-category.json
+++ b/compliance-kit/v1.0/fixtures/control/request-invalid-category.json
@@ -1,0 +1,1 @@
+{"action":"enable","categories":["db"],"options":{"temporary":false}}

--- a/compliance-kit/v1.0/fixtures/control/request-missing-categories.json
+++ b/compliance-kit/v1.0/fixtures/control/request-missing-categories.json
@@ -1,0 +1,1 @@
+{"action":"enable"}

--- a/compliance-kit/v1.0/fixtures/control/response-200.json
+++ b/compliance-kit/v1.0/fixtures/control/response-200.json
@@ -1,0 +1,1 @@
+{"protocol":"rdcp/1.0","timestamp":"2025-09-17T10:30:00.000Z","action":"enable","categories":["DATABASE"],"status":"success","message":"Enabled categories","changes":[{"category":"DATABASE","previousState":false,"newState":true,"temporary":true,"effectiveAt":"2025-09-17T10:30:00.000Z","expiresAt":"2025-09-17T10:45:00.000Z"}]}

--- a/compliance-kit/v1.0/fixtures/discovery/request-tenant-invalid.json
+++ b/compliance-kit/v1.0/fixtures/discovery/request-tenant-invalid.json
@@ -1,0 +1,1 @@
+{"headers":{"X-RDCP-Tenant-ID":"tenant with spaces"}}

--- a/compliance-kit/v1.0/fixtures/discovery/request-valid.json
+++ b/compliance-kit/v1.0/fixtures/discovery/request-valid.json
@@ -1,0 +1,1 @@
+{"headers":{"X-RDCP-Tenant-ID":"TENANT_ID"}}

--- a/compliance-kit/v1.0/fixtures/discovery/response-200.json
+++ b/compliance-kit/v1.0/fixtures/discovery/response-200.json
@@ -1,0 +1,18 @@
+{
+  "protocol": "rdcp/1.0",
+  "timestamp": "2025-09-17T10:30:00.000Z",
+  "categories": [
+    {
+      "name": "DATABASE",
+      "description": "Database operations",
+      "enabled": true,
+      "temporary": false,
+      "metrics": { "callsTotal": 1234, "callsPerSecond": 2.3 }
+    }
+  ],
+  "performance": {
+    "totalCalls": 45678,
+    "callsPerSecond": 2.3,
+    "categoryBreakdown": { "DATABASE": 1234 }
+  }
+}

--- a/compliance-kit/v1.0/fixtures/errors/401-unauthorized.json
+++ b/compliance-kit/v1.0/fixtures/errors/401-unauthorized.json
@@ -1,0 +1,1 @@
+{"error":{"code":"UNAUTHORIZED","message":"Authentication required","protocol":"rdcp/1.0"}}

--- a/compliance-kit/v1.0/fixtures/errors/401-unauthorized.json
+++ b/compliance-kit/v1.0/fixtures/errors/401-unauthorized.json
@@ -1,1 +1,1 @@
-{"error":{"code":"UNAUTHORIZED","message":"Authentication required","protocol":"rdcp/1.0"}}
+{"error":{"code":"RDCP_AUTH_REQUIRED","message":"Authentication required","protocol":"rdcp/1.0"}}

--- a/compliance-kit/v1.0/fixtures/errors/403-forbidden.json
+++ b/compliance-kit/v1.0/fixtures/errors/403-forbidden.json
@@ -1,1 +1,1 @@
-{"error":{"code":"FORBIDDEN","message":"Insufficient permissions","protocol":"rdcp/1.0"}}
+{"error":{"code":"RDCP_FORBIDDEN","message":"Insufficient permissions","protocol":"rdcp/1.0"}}

--- a/compliance-kit/v1.0/fixtures/errors/403-forbidden.json
+++ b/compliance-kit/v1.0/fixtures/errors/403-forbidden.json
@@ -1,0 +1,1 @@
+{"error":{"code":"FORBIDDEN","message":"Insufficient permissions","protocol":"rdcp/1.0"}}

--- a/compliance-kit/v1.0/fixtures/errors/404-not-found.json
+++ b/compliance-kit/v1.0/fixtures/errors/404-not-found.json
@@ -1,0 +1,1 @@
+{"error":{"code":"NOT_FOUND","message":"Resource not found","protocol":"rdcp/1.0"}}

--- a/compliance-kit/v1.0/fixtures/errors/404-not-found.json
+++ b/compliance-kit/v1.0/fixtures/errors/404-not-found.json
@@ -1,1 +1,1 @@
-{"error":{"code":"NOT_FOUND","message":"Resource not found","protocol":"rdcp/1.0"}}
+{"error":{"code":"RDCP_NOT_FOUND","message":"Resource not found","protocol":"rdcp/1.0"}}

--- a/compliance-kit/v1.0/fixtures/status/response-200.json
+++ b/compliance-kit/v1.0/fixtures/status/response-200.json
@@ -1,0 +1,1 @@
+{"protocol":"rdcp/1.0","timestamp":"2025-09-17T10:30:00.000Z","enabled":true,"categories":{"DATABASE":true},"performance":{"totalCalls":45678,"callsPerSecond":2.3}}

--- a/compliance-kit/v1.0/fixtures/status/response-200.json
+++ b/compliance-kit/v1.0/fixtures/status/response-200.json
@@ -1,1 +1,1 @@
-{"protocol":"rdcp/1.0","timestamp":"2025-09-17T10:30:00.000Z","enabled":true,"categories":{"DATABASE":true},"performance":{"totalCalls":45678,"callsPerSecond":2.3}}
+{"protocol":"rdcp/1.0","timestamp":"2025-09-17T10:30:00.000Z","enabled":true,"categories":{"DATABASE":true},"performance":{"callsTotal":45678,"callsPerSecond":2.3}}

--- a/compliance-kit/v1.0/fixtures/well-known/response-200.json
+++ b/compliance-kit/v1.0/fixtures/well-known/response-200.json
@@ -1,0 +1,23 @@
+{
+  "protocol": "rdcp/1.0",
+  "endpoints": {
+    "discovery": "/rdcp/v1/discovery",
+    "control": "/rdcp/v1/control",
+    "status": "/rdcp/v1/status",
+    "health": "/rdcp/v1/health"
+  },
+  "capabilities": {
+    "multiTenancy": true,
+    "performanceMetrics": true,
+    "temporaryControls": true,
+    "auditTrail": true
+  },
+  "security": {
+    "level": "standard",
+    "methods": ["api-key", "bearer"],
+    "scopes": ["discovery", "status", "control", "admin"],
+    "required": true,
+    "keyRotation": true,
+    "tokenRefresh": true
+  }
+}

--- a/compliance-kit/v1.0/sequences/enable-and-verify.json
+++ b/compliance-kit/v1.0/sequences/enable-and-verify.json
@@ -1,0 +1,1 @@
+{"steps":[{"use":"control-enable-200"},{"request":{"method":"GET","path":"/rdcp/v1/status"},"assert":{"status":200,"schema":"schema/v1/endpoints/status-response.json","bodyContains":{"categories":{"DATABASE":true}}}}]}

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,5 +1,3 @@
 # API Reference
 
-```redoc
-spec-url: ../v1/openapi.json
-```
+<redoc src="v1/openapi.json"></redoc>

--- a/docs/compliance-kit.md
+++ b/docs/compliance-kit.md
@@ -1,0 +1,9 @@
+# Compliance Kit (v1.0)
+
+Use this kit to test RDCP v1.0 implementations:
+
+- Download fixtures in compliance-kit/v1.0/
+- Follow README for curl instructions
+- See assertions and the enable‑and‑verify sequence for behavior checks
+
+CI: The repository validates fixtures against JSON Schemas on each PR.

--- a/docs/compliance-kit/v1.0/MANIFEST.md
+++ b/docs/compliance-kit/v1.0/MANIFEST.md
@@ -1,0 +1,25 @@
+# Compliance Kit Test Manifest (v1.0)
+
+This page summarizes the tests and sequences defined in MANIFEST.json.
+
+## Tests
+
+| ID | Name | Method | Path | Expected | Schema |
+|---|---|---|---|---|---|
+| well-known-200 | Well-known discovery returns protocol info | GET | /.well-known/rdcp | 200 | schema/v1/endpoints/protocol-discovery.json |
+| discovery-200 | Discovery lists categories | GET | /rdcp/v1/discovery | 200 | schema/v1/endpoints/discovery-response.json |
+| discovery-tenant-invalid-400 | Discovery rejects invalid tenant header | GET | /rdcp/v1/discovery | 400 | schema/v1/responses/error.json |
+| control-enable-200 | Control enable DATABASE succeeds | POST | /rdcp/v1/control | 200 | schema/v1/endpoints/control-response.json |
+| control-invalid-action-400 | Control invalid action rejected | POST | /rdcp/v1/control | 400 | schema/v1/responses/error.json |
+| control-invalid-category-400 | Control invalid category rejected | POST | /rdcp/v1/control | 400 | schema/v1/responses/error.json |
+| control-missing-categories-400 | Control missing categories rejected | POST | /rdcp/v1/control | 400 | schema/v1/responses/error.json |
+| status-200 | Status endpoint returns current states | GET | /rdcp/v1/status | 200 | schema/v1/endpoints/status-response.json |
+| errors-401 | Protected endpoints require auth | GET | /rdcp/v1/status | 401 | schema/v1/responses/error.json |
+| errors-403 | Insufficient scope rejected | POST | /rdcp/v1/control | 403 | schema/v1/responses/error.json |
+| errors-404 | Unknown category returns 404 | POST | /rdcp/v1/control | 404 | schema/v1/responses/error.json |
+
+## Sequences
+
+- enable-and-verify — Enable DATABASE then verify via status
+  1. POST /rdcp/v1/control (enable)
+  2. GET /rdcp/v1/status → expect categories.DATABASE === true

--- a/docs/compliance-kit/v1.0/README.md
+++ b/docs/compliance-kit/v1.0/README.md
@@ -1,0 +1,16 @@
+# RDCP Compliance Kit v1.0 — Overview
+
+The RDCP Compliance Kit helps verify that an implementation conforms to the RDCP v1.0 specification using portable JSON fixtures and curl.
+
+What this section provides:
+- What the kit is and how to use it
+- A browsable Test Manifest and Assertions
+- A minimal guide to running local validation
+
+Quick links:
+- Test Manifest: MANIFEST.md
+- Assertions: assertions.md
+- Running Tests: running-tests.md
+- Source fixtures (GitHub): https://github.com/mojoatomic/rdcp-protocol/tree/main/compliance-kit/v1.0
+
+The fixtures themselves live in the repository and are downloadable artifacts. Use this documentation to understand what tests exist and how to run them; use the GitHub directory to fetch the raw JSON files.

--- a/docs/compliance-kit/v1.0/assertions.md
+++ b/docs/compliance-kit/v1.0/assertions.md
@@ -1,0 +1,37 @@
+# Assertions and Coverage (v1.0)
+
+This document explains what each fixture/sequence is asserting against the RDCP v1.0 specification.
+
+## Endpoints
+
+- `/.well-known/rdcp` → WellKnownResponse
+  - Asserts required fields: protocol, endpoints, capabilities, security
+- `/rdcp/v1/discovery` → DiscoveryResponse
+  - Asserts timestamp format, categories array, performance object
+  - Negative: invalid `X-RDCP-Tenant-ID` fails with 400 ErrorResponse
+- `/rdcp/v1/control` → ControlRequest/ControlResponse
+  - Valid: action=enable + categories=["DATABASE"] returns 200 ControlResponse
+  - Negative: invalid action, invalid category pattern, missing categories → 400 ErrorResponse
+- `/rdcp/v1/status` → StatusResponse
+  - Asserts enabled flag and categories map
+
+## Behavior sequence
+
+- `enable-and-verify`:
+  1) POST control (enable DATABASE)
+  2) GET status → categories.DATABASE === true
+
+## Error conditions
+
+- 401 Unauthorized: protected endpoints with missing/invalid auth
+- 403 Forbidden: insufficient scopes/permissions
+- 404 Not Found: unknown category
+
+## Schema references
+
+- Common: schema/v1/common/rdcp-common.json
+- Well-known: schema/v1/endpoints/protocol-discovery.json
+- Discovery: schema/v1/endpoints/discovery-response.json
+- Control (request/response): schema/v1/endpoints/control-request.json, control-response.json
+- Status: schema/v1/endpoints/status-response.json
+- Error envelope: schema/v1/responses/error.json

--- a/docs/compliance-kit/v1.0/running-tests.md
+++ b/docs/compliance-kit/v1.0/running-tests.md
@@ -1,0 +1,17 @@
+# Running Tests and Validation (v1.0)
+
+## Running Validation Locally
+```bash
+# Install dependencies
+npm install
+
+# Validate all fixtures
+node scripts/validate-fixtures.js
+```
+If validation fails, check:
+- Fixture conforms to schema structure
+- Error codes match defined values in error-codes.md
+- Field names match exactly (e.g., callsTotal not totalCalls)
+
+For endpoint curl examples, see the Compliance Kit README in the repository:
+- https://github.com/mojoatomic/rdcp-protocol/tree/main/compliance-kit/v1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,4 +92,5 @@ nav:
     - Reference: api/reference.md
     - Playground: api/playground.md
   - Error Codes: error-codes.md
+  - Compliance Kit: compliance-kit.md
   - Compliance Report: PROTOCOL-COMPLIANCE-REPORT.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,5 +92,9 @@ nav:
     - Reference: api/reference.md
     - Playground: api/playground.md
   - Error Codes: error-codes.md
-  - Compliance Kit: compliance-kit.md
+  - Compliance Kit:
+    - Overview: compliance-kit/v1.0/README.md
+    - Test Manifest: compliance-kit/v1.0/MANIFEST.md
+    - Assertions: compliance-kit/v1.0/assertions.md
+    - Running Tests: compliance-kit/v1.0/running-tests.md
   - Compliance Report: PROTOCOL-COMPLIANCE-REPORT.md

--- a/scripts/validate-fixtures.js
+++ b/scripts/validate-fixtures.js
@@ -1,17 +1,53 @@
 #!/usr/bin/env node
 // Validate selected fixtures against versioned JSON Schemas (Phase 1)
-import fs from 'node:fs';
-import path from 'node:path';
-import Ajv from 'ajv';
-import addFormats from 'ajv-formats';
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
 
 const ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(ajv);
 
 function loadJSON(p) { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+
+// Preload all protocol schemas so $id/$ref resolution works
+function preloadSchemas(rootDir) {
+  const base = process.cwd();
+  function toPosix(p) { return p.split(path.sep).join('/'); }
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      const stat = fs.statSync(full);
+      if (stat.isDirectory()) walk(full);
+      else if (entry.endsWith('.json')) {
+        const s = loadJSON(full);
+        // Register by $id if present
+        if (s.$id) ajv.addSchema(s, s.$id);
+        // Also register by absolute and repo-relative POSIX paths to satisfy relative $ref resolution
+        const absKey = toPosix(path.resolve(full));
+        const relKey = toPosix(path.relative(base, full));
+        ajv.addSchema(s, absKey);
+        ajv.addSchema(s, relKey);
+      }
+    }
+  }
+  walk(rootDir);
+}
+
+function toPosixPath(p) { return p.split(path.sep).join('/'); }
+
 function validateWith(schemaPath, dataPath) {
-  const schema = loadJSON(schemaPath);
-  const validate = ajv.compile(schema);
+  // Prefer using the preloaded schema key (repo-relative POSIX path)
+  const key = toPosixPath(schemaPath);
+  let validate = ajv.getSchema(key);
+
+  // Fallback: try by $id or compile if not preloaded for some reason
+  if (!validate) {
+    const schema = loadJSON(schemaPath);
+    const id = schema.$id || key;
+    validate = ajv.getSchema(id) || ajv.compile(schema);
+  }
+
   const data = loadJSON(dataPath);
   const ok = validate(data);
   if (!ok) {
@@ -26,6 +62,9 @@ function validateWith(schemaPath, dataPath) {
 // Base paths (run from repo root)
 const base = process.cwd();
 const kit = path.join(base, 'compliance-kit', 'v1.0');
+
+// Ensure schemas are preloaded for $ref resolution
+preloadSchemas(path.join(base, 'schema'));
 
 // Positive fixtures to validate
 validateWith('schema/v1/endpoints/protocol-discovery.json', path.join(kit, 'fixtures/well-known/response-200.json'));

--- a/scripts/validate-fixtures.js
+++ b/scripts/validate-fixtures.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Validate selected fixtures against versioned JSON Schemas (Phase 1)
+import fs from 'node:fs';
+import path from 'node:path';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+
+function loadJSON(p) { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+function validateWith(schemaPath, dataPath) {
+  const schema = loadJSON(schemaPath);
+  const validate = ajv.compile(schema);
+  const data = loadJSON(dataPath);
+  const ok = validate(data);
+  if (!ok) {
+    console.error(`\n❌ Validation failed for ${dataPath} against ${schemaPath}`);
+    console.error(validate.errors);
+    process.exitCode = 1;
+  } else {
+    console.log(`✅ ${dataPath} ✓`);
+  }
+}
+
+// Base paths (run from repo root)
+const base = process.cwd();
+const kit = path.join(base, 'compliance-kit', 'v1.0');
+
+// Positive fixtures to validate
+validateWith('schema/v1/endpoints/protocol-discovery.json', path.join(kit, 'fixtures/well-known/response-200.json'));
+validateWith('schema/v1/endpoints/discovery-response.json', path.join(kit, 'fixtures/discovery/response-200.json'));
+validateWith('schema/v1/endpoints/control-request.json', path.join(kit, 'fixtures/control/request-enable-valid.json'));
+validateWith('schema/v1/endpoints/control-response.json', path.join(kit, 'fixtures/control/response-200.json'));
+validateWith('schema/v1/endpoints/status-response.json', path.join(kit, 'fixtures/status/response-200.json'));
+validateWith('schema/v1/responses/error.json', path.join(kit, 'fixtures/errors/401-unauthorized.json'));
+validateWith('schema/v1/responses/error.json', path.join(kit, 'fixtures/errors/403-forbidden.json'));
+validateWith('schema/v1/responses/error.json', path.join(kit, 'fixtures/errors/404-not-found.json'));
+
+console.log('\nCompliance kit fixtures validated.');


### PR DESCRIPTION
- **docs(api): fix Redoc tag to use src with local path (v1/openapi.json)**
- **docs(compliance-kit): add v1.0 fixtures, manifest, assertions, CI validation; add docs page and nav**
- **fix: preload schemas and align fixtures with schema enums for AJV validation**
- **docs: add minimal compliance kit pages and navigation; include local validation instructions**
- **ci: allow manual docs deploy via workflow_dispatch**
