### PR TITLE
ci(pages): push built site directly to gh-pages (force)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,12 +80,6 @@ jobs:
           git add api/index.html
           git commit -m 'chore(pages): add /api redirect to /latest/api/' || true
 
-      - name: Push pages update branch and open PR to gh-pages
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Push pages to gh-pages (force)
         run: |
-          BR="pages/update-${GITHUB_SHA:0:7}-${GITHUB_RUN_ID}"
-          git push origin HEAD:"$BR"
-          gh pr create -R "${GITHUB_REPOSITORY}" --base gh-pages --head "$BR" \
-            --title "docs(pages): publish site update" \
-            --body "Automated pages deploy via PR. Includes mike versioning update and redirect."
+          git push origin HEAD:gh-pages --force


### PR DESCRIPTION
Deploy docs by building with mike and force-pushing gh-pages. Removes PR creation (GH Actions cannot create PRs by default). Restores standard MkDocs/mike behavior.