### PR TITLE
docs: minimal README pointing to published docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,24 +62,7 @@ jobs:
           mike deploy --update-aliases 1.0 latest
           mike set-default latest
 
-      - name: Prepare /api redirect in gh-pages tree
-        run: |
-          git checkout gh-pages || git checkout -b gh-pages
-          mkdir -p api
-          cat > api/index.html <<'REDIR'
-          <!doctype html>
-          <html>
-            <head>
-              <meta http-equiv="refresh" content="0; url=../latest/api/" />
-              <link rel="canonical" href="../latest/api/" />
-              <meta name="robots" content="noindex" />
-            </head>
-            <body>Redirecting to latest API docs…</body>
-          </html>
-          REDIR
-          git add api/index.html
-          git commit -m 'chore(pages): add /api redirect to /latest/api/' || true
 
-      - name: Push pages to gh-pages (force)
+      - name: Push gh-pages (force)
         run: |
-          git push origin HEAD:gh-pages --force
+          git push origin gh-pages --force

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# RDCP Protocol
+
+Authoritative documentation:
+- Stable (v1.0): https://mojoatomic.github.io/rdcp-protocol/1.0/
+- Latest: https://mojoatomic.github.io/rdcp-protocol/latest/
+
+This repository contains the protocol specification, versioned JSON Schemas, and the published documentation site built with MkDocs + mike.
+
+Notes:
+- docs/index.md is the canonical homepage for the site.
+- The gh-pages branch is build output; it is overwritten on each deploy.
+- Site versioning is managed by mike (aliases include `latest` and specific versions like `1.0`).


### PR DESCRIPTION
Set README.md as a minimal pointer to the published documentation:\n\n- Stable (v1.0): https://mojoatomic.github.io/rdcp-protocol/1.0/\n- Latest: https://mojoatomic.github.io/rdcp-protocol/latest/\n\ndocs/index.md remains the canonical homepage. gh-pages is build output (overwritten each deploy); mike manages versioning.